### PR TITLE
Fixes issue #1: wrong GitHub url in README.md

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -77,7 +77,12 @@ finder = :InstallModules        ; prevents test inputs being flagged
 [Test::TidyAll]
 
 ;; -- Additional information
-[GithubMeta]                ; Grab the repo metadata
+[MetaResources]
+homepage          = https://github.com/FormFu/HTML-FormFu-MultiForm
+repository.url    = git://github.com/FormFu/HTML-FormFu-MultiForm.git
+repository.web    = https://github.com/FormFu/HTML-FormFu-MultiForm
+repository.type   = git
+
 [PodWeaver]                 ; Mangle the pod a bit
 [CheckChangeLog]            ; Make sure we have a change set
 


### PR DESCRIPTION
Fixes issue #1. 
Use `[MetaResources]` instead of `[GithubMeta]` to get correct GitHub URL.

_[[Assigned by [pullrequest.club](https://pullrequest.club/)]]_